### PR TITLE
Remove exact argument to read_namespaced_pod

### DIFF
--- a/copypod/main.py
+++ b/copypod/main.py
@@ -156,7 +156,7 @@ def main():
 
     # Get details of the source pod
     try:
-        src_pod = k8s_client.read_namespaced_pod(pod_name, args.namespace, exact=True)
+        src_pod = k8s_client.read_namespaced_pod(pod_name, args.namespace)
     except ApiException as error:
         print(
             f"Error occurred when trying to get information about existing pod: {error.reason}",


### PR DESCRIPTION
This is causing memworld-mall deploys to fail as the `exact` argument is deprecated in newer versions of kubernetes.  

`pipfile.lock` specifies version `==20.13.0` for the kubernetes package but when testing the installation with pip it installs the latest version, `21.7.0`. I'm guessing `setup.py` needs changing to make it more reliable but I've tested this change with both versions and it works fine so I think it's worth the change anyway