### PR TITLE
Add support for setting cpu/memory requests and limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ $ pipx install copypod
 
     $ copypod --help
     usage: copypod [-h] [--context CONTEXT] [-n NAMESPACE] (-l SELECTOR | -p POD) [--container CONTAINER] [-c COMMAND] [-i INTERACTIVE] [--image IMAGE]
-                   [--cap-add CAP_ADD] [-s SUFFIX] [-e ENV]
+                   [--cap-add CAP_ADD] [-s SUFFIX] [-e ENV] [--limit-cpu LIMIT_CPU] [--limit-memory LIMIT_MEMORY] [--request-cpu REQUEST_CPU]
+                   [--request-memory REQUEST_MEMORY]
 
     Copy a Kubernetes pod and run commands in its environment.
 
@@ -54,6 +55,14 @@ $ pipx install copypod
       --cap-add CAP_ADD     Capabilities to add for the copied pod, can be specified multiple times (default: None)
       -s, --suffix SUFFIX   Set custom suffix for the new pod, otherwise a random suffix is generated (default: None)
       -e, --env ENV         Environment variable to set (NAME=value), can be specified multiple times (default: None)
+      --limit-cpu LIMIT_CPU
+                            Set CPU limit for the copied pod. '1' = one core, '500m' = half a core (default: None)
+      --limit-memory LIMIT_MEMORY
+                            Set memory limit for the copied pod. E.g. '256Mi', '1Gi' (default: None)
+      --request-cpu REQUEST_CPU
+                            Set requested CPU for the copied pod. '1' = one core, '500m' = half a core (default: None)
+      --request-memory REQUEST_MEMORY
+                            Set requested memory for the copied pod. E.g. '256Mi', '1Gi' (default: None)
 
     If the `--interactive` flag is provided, the copied pod will be removed immediately after the command exits, otherwise the name of the pod will be printed.
 

--- a/copypod/main.py
+++ b/copypod/main.py
@@ -88,6 +88,26 @@ def parse_cli_arguments() -> argparse.Namespace:
         action="append",
         help="Environment variable to set (NAME=value), can be specified multiple times",
     )
+    parser.add_argument(
+        "--limit-cpu",
+        type=str,
+        help="Set CPU limit for the copied pod. '1' = one core, '500m' = half a core",
+    )
+    parser.add_argument(
+        "--limit-memory",
+        type=str,
+        help="Set memory limit for the copied pod. E.g. '256Mi', '1Gi'",
+    )
+    parser.add_argument(
+        "--request-cpu",
+        type=str,
+        help="Set requested CPU for the copied pod. '1' = one core, '500m' = half a core",
+    )
+    parser.add_argument(
+        "--request-memory",
+        type=str,
+        help="Set requested memory for the copied pod. E.g. '256Mi', '1Gi'",
+    )
     return parser.parse_args()
 
 
@@ -126,6 +146,13 @@ def main() -> None:
         pod = pod_config.set_pod_name(pod, args.suffix)
         pod = pod_config.configure_container(pod, args.command, args.image, args.env)
         pod = pod_config.add_capabilities(pod, args.cap_add)
+        pod = pod_config.set_resources(
+            pod,
+            limit_cpu=args.limit_cpu,
+            limit_memory=args.limit_memory,
+            request_cpu=args.request_cpu,
+            request_memory=args.request_memory,
+        )
 
         kube.create_pod(client, pod)
         kube.wait_until_running(client, pod)

--- a/copypod/pod_config.py
+++ b/copypod/pod_config.py
@@ -20,7 +20,13 @@ from getpass import getuser
 from itertools import chain
 from random import choices
 
-from kubernetes.client import V1Capabilities, V1EnvVar, V1Pod, V1SecurityContext
+from kubernetes.client import (
+    V1Capabilities,
+    V1EnvVar,
+    V1Pod,
+    V1ResourceRequirements,
+    V1SecurityContext,
+)
 
 from .exceptions import CopypodError
 
@@ -71,6 +77,10 @@ def clear_fields(pod: V1Pod) -> V1Pod:
     pod.spec.containers[0].readiness_probe = None
     pod.spec.containers[0].startup_probe = None
     pod.spec.containers[0].resources = None
+
+    pod.spec.containers[0].resources = V1ResourceRequirements(
+        requests={"memory": "1Gi"}
+    )
 
     pod.spec.affinity = None
     pod.spec.node_name = None
@@ -132,5 +142,31 @@ def add_capabilities(pod: V1Pod, capabilities: list[str]) -> V1Pod:
         pod.spec.containers[0].security_context.capabilities.add.extend(capabilities)
     else:
         pod.spec.containers[0].security_context.capabilities.add = capabilities
+
+    return pod
+
+
+def set_resources(
+    pod: V1Pod,
+    limit_cpu: str | None,
+    limit_memory: str | None,
+    request_cpu: str | None,
+    request_memory: str | None,
+) -> V1Pod:
+    limits = {}
+    if limit_cpu:
+        limits["cpu"] = limit_cpu
+    if limit_memory:
+        limits["memory"] = limit_memory
+
+    requests = {}
+    if request_cpu:
+        requests["cpu"] = limit_cpu
+    if request_memory:
+        requests["memory"] = limit_memory
+
+    pod.spec.containers[0].resources = V1ResourceRequirements(
+        limits=limits, requests=requests
+    )
 
     return pod


### PR DESCRIPTION
This can be helpful when you know what you need the copied pod for either may require a non-trivial amount of resources, so you want Kubernetes to take that into account when scheduling the pod, or it could be for limiting the resources the copied pod can use so it doesn't impact other workloads running in the same cluster.